### PR TITLE
riscv: dts: thead: downclock SD card for LPi4A

### DIFF
--- a/arch/riscv/dts/light-lpi4a-laptop.dts
+++ b/arch/riscv/dts/light-lpi4a-laptop.dts
@@ -43,3 +43,8 @@
 	/delete-property/ lcd-en-gpios;
 	/delete-property/ lcd-bias-en-gpios;
 };
+
+&sdhci0 {
+	max-frequency = <35000000>;
+	status = "okay";
+};


### PR DESCRIPTION
It's reported that @198MHz some R/W error will happen.

https://github.com/revyos/thead-kernel/commit/215f2c97bd0cbeb1c661483ef5c774072fbdb45c.patch