### PR TITLE
Fix two compiler errors on GCC 14

### DIFF
--- a/arch/riscv/lib/bootm.c
+++ b/arch/riscv/lib/bootm.c
@@ -110,7 +110,7 @@ void next_stage(void)
 bool has_reset_sample(ulong dtb_addr)
 {
 	int node_offset;
-	node_offset = fdt_path_offset(dtb_addr, "/soc/reset-sample");
+	node_offset = fdt_path_offset((void *)dtb_addr, "/soc/reset-sample");
 	if (node_offset < 0) {
 		printf("## fdt has no reset_sample\n");
 		return false;
@@ -160,8 +160,8 @@ static void boot_jump_linux(bootm_headers_t *images, int flag)
 
 	announce_and_cleanup(fake);
 
-	_load_start = kernel;
-	_dtb_addr = images->ft_addr;
+	_load_start = (ulong)kernel;
+	_dtb_addr = (ulong)(images->ft_addr);
 	_dyn_info_addr = (ulong)&opensbi_info;
 	if (!has_reset_sample(_dtb_addr)) {
 		opensbi_info.magic = FW_DYNAMIC_INFO_MAGIC_VALUE;

--- a/board/thead/light-c910/lpddr4/src/ddr_common_func.c
+++ b/board/thead/light-c910/lpddr4/src/ddr_common_func.c
@@ -49,7 +49,7 @@ int get_ddr_rank_number() {
 #ifdef CONFIG_DDR_MSG
 	DDR_DEBUG("unsupported ddr rank type!!!\n");
 #endif
-    return NULL;
+    return 0;
 #endif
 }
 

--- a/board/thead/light-c910/lpddr4/src/ddr_common_func.c
+++ b/board/thead/light-c910/lpddr4/src/ddr_common_func.c
@@ -3,6 +3,7 @@
 #include "../include/common_lib.h"
 #include "../include/ddr_common_func.h"
 #include "../include/ddr_retention.h"
+#include "../include/pinmux.h"
 
 DDR_SYSREG_REG_SW_REG_S ddr_sysreg;
 

--- a/board/thead/light-c910/lpddr4/src/ddr_retention.c
+++ b/board/thead/light-c910/lpddr4/src/ddr_retention.c
@@ -1,6 +1,7 @@
 #include "../include/common_lib.h"
 #include "../include/ddr_common_func.h"
 #include "../include/ddr_retention.h"
+#include "../include/pinmux.h"
 
 /*
 /// data structure to store register address, value pairs

--- a/board/thead/light-c910/spl.c
+++ b/board/thead/light-c910/spl.c
@@ -338,37 +338,37 @@ int boundary_verify(unsigned long boundary) {
 	phys_addr_t verify_addr4 = (phys_addr_t)boundary + CONFIG_SYS_SDRAM_BASE;
 
 	// verify data accessing result firstly
-	writel(MAGIC_DATA2, verify_addr);
+	writel(MAGIC_DATA2, (void *)verify_addr);
 	invalidate_dcache_range(verify_addr, verify_addr + CONFIG_SYS_CACHELINE_SIZE);
-	if (readl(verify_addr) != MAGIC_DATA2) {
+	if (readl((void *)verify_addr) != MAGIC_DATA2) {
 		printf("ddr rw test failed\n");
 		return -1;
 	}
-	writel(MAGIC_DATA, verify_addr);  // writing at beginning
+	writel(MAGIC_DATA, (void *)verify_addr);  // writing at beginning
 	invalidate_dcache_range(verify_addr, verify_addr + CONFIG_SYS_CACHELINE_SIZE);
-	if (readl(verify_addr) != MAGIC_DATA) {
+	if (readl((void *)verify_addr) != MAGIC_DATA) {
 		printf("ddr rw test failed\n");
 		return -1;
 	}
-	writel(MAGIC_DATA2, verify_addr2); // writing at one-quarter addr
-	writel(MAGIC_DATA3, verify_addr3); // writing at half addr
+	writel(MAGIC_DATA2, (void *)verify_addr2); // writing at one-quarter addr
+	writel(MAGIC_DATA3, (void *)verify_addr3); // writing at half addr
 	invalidate_dcache_range(verify_addr, verify_addr + CONFIG_SYS_CACHELINE_SIZE);
 	invalidate_dcache_range(verify_addr2, verify_addr2 + CONFIG_SYS_CACHELINE_SIZE);
 	invalidate_dcache_range(verify_addr3, verify_addr3 + CONFIG_SYS_CACHELINE_SIZE);
 
 	if (boundary == (unsigned long)MAXIMAL_DDR_DENSITY_MB * UNIT_MB) { // boundary by design
-		if ((readl(verify_addr) == MAGIC_DATA) &&
-			(readl(verify_addr2) == MAGIC_DATA2) &&
-			(readl(verify_addr3) == MAGIC_DATA3))
+		if ((readl((void *)verify_addr) == MAGIC_DATA) &&
+			(readl((void *)verify_addr2) == MAGIC_DATA2) &&
+			(readl((void *)verify_addr3) == MAGIC_DATA3))
 			return 0;
 	}
 	else {
-		writel(MAGIC_DATA4, verify_addr4); // writing out of boundary
+		writel(MAGIC_DATA4, (void *)verify_addr4); // writing out of boundary
 		invalidate_dcache_range(verify_addr4, verify_addr4 + CONFIG_SYS_CACHELINE_SIZE);
-		if ((readl(verify_addr) == MAGIC_DATA4) && // overwrite by verify_addr4
-			(readl(verify_addr2) == MAGIC_DATA2) &&
-			(readl(verify_addr3) == MAGIC_DATA3) &&
-			(readl(verify_addr4) == MAGIC_DATA4))
+		if ((readl((void *)verify_addr) == MAGIC_DATA4) && // overwrite by verify_addr4
+			(readl((void *)verify_addr2) == MAGIC_DATA2) &&
+			(readl((void *)verify_addr3) == MAGIC_DATA3) &&
+			(readl((void *)verify_addr4) == MAGIC_DATA4))
 			return 0;
 	}
 

--- a/cmd/pxe_utils.c
+++ b/cmd/pxe_utils.c
@@ -335,7 +335,7 @@ static int label_localboot(struct pxe_label *label)
  * Loads fdt overlays specified in 'fdtoverlays'.
  */
 #ifdef CONFIG_OF_LIBFDT_OVERLAY
-static void label_boot_fdtoverlay(struct cmd_tbl *cmdtp, struct pxe_label *label)
+static void label_boot_fdtoverlay(cmd_tbl_t *cmdtp, struct pxe_label *label)
 {
 	char *fdtoverlay = label->fdtoverlays;
 	struct fdt_header *working_fdt;


### PR DESCRIPTION
On GCC 14.2.0 I am getting two compiler errors that I resolved with these 2 commits.

```
cmd/pxe_utils.c:388:43: error: passing argument 1 of 'get_relfile_envaddr' from incompatible pointer type [-Wincompatible-pointer-types]
  388 |                 err = get_relfile_envaddr(cmdtp, overlayfile,
      |                                           ^~~~~
      |                                           |
      |                                           struct cmd_tbl *
cmd/pxe_utils.c:216:43: note: expected 'cmd_tbl_t *' {aka 'struct cmd_tbl_s *'} but argument is of type 'struct cmd_tbl *'
  216 | static int get_relfile_envaddr(cmd_tbl_t *cmdtp, const char *file_path,
      |                                ~~~~~~~~~~~^~~~~

cmd/pxe_utils.c: In function 'label_boot':
cmd/pxe_utils.c:617:55: error: passing argument 1 of 'label_boot_fdtoverlay' from incompatible pointer type [-Wincompatible-pointer-types]
  617 |                                 label_boot_fdtoverlay(cmdtp, label);
      |                                                       ^~~~~
      |                                                       |
      |                                                       cmd_tbl_t * {aka struct cmd_tbl_s *}
cmd/pxe_utils.c:338:51: note: expected 'struct cmd_tbl *' but argument is of type 'cmd_tbl_t *' {aka 'struct cmd_tbl_s *'}
  338 | static void label_boot_fdtoverlay(struct cmd_tbl *cmdtp, struct pxe_label *label)
      |                                   ~~~~~~~~~~~~~~~~^~~~~
```

```
board/thead/light-c910/lpddr4/src/ddr_common_func.c: In function 'get_ddr_rank_number':
board/thead/light-c910/lpddr4/src/ddr_common_func.c:52:12: error: returning 'void *' from a function with return type 'int' makes integer from pointer without a cast [-Wint-conversion]
   52 |     return NULL;
      |            ^~~~
  LD      drivers/clk/tegra/built-in.o
  CC      board/thead/light-c910/lpddr4/src/ddr_retention.o
  CC      drivers/clk/clk_fixed_rate.o
  LD      drivers/power/mfd/built-in.o
```

This branch is based on https://github.com/revyos/thead-u-boot/pull/46 which also fixed various errors.