### PR TITLE
enable PWM fan in uboot for LPi4A and Meles

### DIFF
--- a/arch/riscv/dts/light-milkv-meles.dts
+++ b/arch/riscv/dts/light-milkv-meles.dts
@@ -9,7 +9,8 @@
 	#size-cells = <2>;
 
 	config {
-		select-gpio = <&gpio1_porta 16 0>;
+		select-gpio = <&gpio1_porta 16 0>; // Enable the blue LED on Milk-V Meles
+		fan-gpio = <&gpio2_porta 4 0>; // Enable the fan on Milk-V Meles, see schematic for details
 	};
 
 	memory@0 {

--- a/board/thead/light-c910/board.c
+++ b/board/thead/light-c910/board.c
@@ -244,7 +244,7 @@ int do_bootslave(cmd_tbl_t * cmdtp, int flag, int argc, char * const argv[])
 }
 #endif
 
-static void light_c910_set_gpio_output_high(void)
+static void light_c910_set_gpio_output_high(const char* gpio_name)
 {
 	ofnode node;
 	struct gpio_desc select_gpio;
@@ -257,9 +257,9 @@ static void light_c910_set_gpio_output_high(void)
 		return;
 	}
 
-	if (gpio_request_by_name_nodev(node, "select-gpio", 0,
+	if (gpio_request_by_name_nodev(node, gpio_name, 0,
 				       &select_gpio, GPIOD_IS_OUT)) {
-		printf("%s: could not find a /config/select-gpio\n", __func__);
+		printf("%s: could not find a /config/%s\n", __func__, gpio_name);
 		return;
 	}
 
@@ -268,7 +268,12 @@ static void light_c910_set_gpio_output_high(void)
 
 int misc_init_r(void)
 {
-	light_c910_set_gpio_output_high();
+	// Enable blue LED
+	light_c910_set_gpio_output_high("select-gpio");
+
+	// Enable fan on some boards(currently only on Meles)
+	// For LPi4A, the fan is controlled by PWM, see lpi4a_fan_pwm_config() in light.c
+	light_c910_set_gpio_output_high("fan-gpio");
 
 	return 0;
 }

--- a/board/thead/light-c910/light.c
+++ b/board/thead/light-c910/light.c
@@ -2402,13 +2402,59 @@ static void light_iopin_init(void)
 }
 #endif
 
+#define PWM_BASE				((void *)0xffec01c000)
+#define PWM_CHAN_REG(chan, off)	(PWM_BASE + (chan) * 0x20 + (off))
+#define PWM_PER_OFFSET			0x08  // Offset for Periodic Control Register
+#define PWM_FP_OFFSET			0x0C  // Offset for First Phase Control Register
+#define PWM_CTRL_OFFSET			0x00  // Offset for Control Register
+// See T-HEAD TH1520 Peripheral Interface User Manual
+// https://dl.sipeed.com/shareURL/LICHEE/licheepi4a/09_Doc
 
 static void light_pwm_config(void)
 {
-	/* pwm0 */
-	writel(0x4b0, (void *)0xFFEC01C008);
-	writel(0x258, (void *)0xFFEC01C00c);
-	writel(0x328, (void *)0xFFEC01C000);
+	/*
+	 * Enable MIPI Display backlight on PWM0.
+	 * Period=1200 clock cycles, Duty Cycle=50%
+	*/
+	// Set PWM Period to 1200 clock cycles
+	writel(0x4b0, PWM_CHAN_REG(0, PWM_PER_OFFSET));
+	// Set PWM First Phase to 600 clock cycles
+	writel(0x258, PWM_CHAN_REG(0, PWM_FP_OFFSET));
+	// Configure PWM Control Register:
+	// [9]  INACTOUT  = 1 (inactive output set to high)
+	// [8]  FPOUT     = 1 (first phase output set to high)
+	// [7:6] EVTRIG   = 00 (event-triggered mode disabled)
+	// [5:4] MODE     = 10 (continuous mode)
+	// [3]   INTEN    = 1 (interrupt enabled)
+	// [2]   CFG_UPDATE = 0 (do not wait for configuration update)
+	// [1]   SOFT_RST = 0 (software reset disabled)
+	// [0]   START    = 0 (PWM start coding enable, rising edge effective)
+	// Final address: 0xffec01c000 + 0x00 (channel 0) + 0x00 (control register offset) = 0xffec01c000
+	writel(0b1100101000, PWM_CHAN_REG(0, PWM_CTRL_OFFSET));
+}
+
+static void lpi4a_fan_pwm_config(void)
+{
+	/*
+	 * Enable fan on PWM1(GPIO10) for Lichee Pi 4A.
+	 * See LPi4A Schematic:
+	 * https://dl.sipeed.com/shareURL/LICHEE/licheepi4a/02_Schematic
+	*/
+	// Set PWM Period to 1200 clock cycles
+	writel(0x4b0, PWM_CHAN_REG(1, PWM_PER_OFFSET));
+	// Set PWM First Phase to 600 clock cycles
+	writel(0x258, PWM_CHAN_REG(1, PWM_FP_OFFSET));
+	// Configure PWM Control Register:
+	// [9]  INACTOUT  = 1 (inactive output set to high)
+	// [8]  FPOUT     = 1 (first phase output set to high)
+	// [7:6] EVTRIG   = 00 (event-triggered mode disabled)
+	// [5:4] MODE     = 10 (continuous mode)
+	// [3]   INTEN    = 0 (interrupt disabled)
+	// [2]   CFG_UPDATE = 0 (do not wait for configuration update)
+	// [1]   SOFT_RST = 0 (software reset disabled)
+	// [0]   START    = 0 (PWM start coding enable, rising edge effective)
+	// Final address: 0xffec01c000 + 0x20 (channel 1) + 0x00 (control register offset) = 0xffec01c020
+	writel(0b1100100000, PWM_CHAN_REG(1, PWM_CTRL_OFFSET));
 }
 
 int board_init(void)
@@ -2425,6 +2471,9 @@ int board_init(void)
 
 	light_pwm_config();
 
+#ifdef CONFIG_TARGET_LIGHT_FM_C910_LPI4A
+	lpi4a_fan_pwm_config();
+#endif
 	return 0;
 }
 


### PR DESCRIPTION
在uboot中启用LPi4A和Meles自带的PWM风扇，以避免刷机时芯片过热。
[LPi4A 原理图](https://dl.sipeed.com/shareURL/LICHEE/licheepi4a/02_Schematic)  [芯片手册](https://dl.sipeed.com/shareURL/LICHEE/licheepi4a/09_Doc)

经过在LiCheePi 4A 16G版上的测试，修改版的uboot固件能够正常启动和刷入系统，并保持风扇工作。
Meles未经测试